### PR TITLE
Fix Path-Rewrite Issue and Remove Unnecessary 'https://' Prefix on Nearspark

### DIFF
--- a/community-edition/hcce.yam
+++ b/community-edition/hcce.yam
@@ -170,7 +170,7 @@ metadata:
   namespace: $Namespace
   annotations:
     kubernetes.io/ingress.class: haproxy
-    haproxy.ingress.kubernetes.io/rewrite-target: /$1
+    haproxy.org/path-rewrite: /nearspark/(.*) /\1
 spec:
   tls:
   - hosts:
@@ -180,7 +180,7 @@ spec:
   - host: cors.$HUB_DOMAIN
     http:
       paths:
-      - path: /nearspark(/|$)(.*)
+      - path: /nearspark
         pathType: Prefix
         backend:
           service:
@@ -811,7 +811,7 @@ spec:
         imagePullPolicy: IfNotPresent
         env:
         - name: turkeyCfg_thumbnail_server
-          value: 'https://cors.$HUB_DOMAIN/nearspark'
+          value: 'cors.$HUB_DOMAIN/nearspark'
         - name: turkeyCfg_base_assets_path
           value: https://assets.$HUB_DOMAIN/hubs/
         - name: turkeyCfg_non_cors_proxy_domains
@@ -881,7 +881,7 @@ spec:
         imagePullPolicy: IfNotPresent
         env:
         - name: turkeyCfg_thumbnail_server
-          value: 'https://cors.$HUB_DOMAIN/nearspark'
+          value: 'cors.$HUB_DOMAIN/nearspark'
         - name: turkeyCfg_base_assets_path
           value: https://assets.$HUB_DOMAIN/spoke/
         - name: turkeyCfg_non_cors_proxy_domains


### PR DESCRIPTION
This pull request addresses the issue where the path-rewrite functionality was not working correctly. Additionally, it removes the unnecessary 'https://' prefix on thumbnail_server.

According to the previous rewrite configuration, if a user makes a request to `https://cors.example.com/nearspark/thumbnail/...`, it should be reformatted and passed to the Nearspark pod as `https://cors.example.com/thumbnail/....` I have modified the configuration to achieve this functionality.

The hubs and spoke code added the `https://` prefix on thumbnail_server, so this prefix is not required in the turkeyCfg_thumbnail_server environment variable. Otherwise, the URL becomes `https://https://cors.example.com/nearspark/thumbnail/...`

