### PR TITLE
Changes deprecated kubernetes.io/ingress.class to spec.ingressClassName

### DIFF
--- a/community-edition/hcce.yam
+++ b/community-edition/hcce.yam
@@ -4,11 +4,11 @@ metadata:
   name: "$Namespace"
   annotations:
     domain: "$HUB_DOMAIN"
-    adm: "$ADM_EMAIL"    
+    adm: "$ADM_EMAIL"
 ---
 ########################################################################
 ###################### configs #########################################
-########################################################################  
+########################################################################
 apiVersion: v1
 kind: Secret
 metadata:
@@ -45,7 +45,7 @@ metadata:
   name: ret
   namespace: $Namespace
   annotations:
-    kubernetes.io/ingress.class: haproxy
+    spec.ingressClassName: haproxy
     haproxy.org/response-set-header: |
       access-control-allow-origin "https://$HUB_DOMAIN"
     haproxy.org/path-rewrite: /api-internal(.*) /_drop_
@@ -72,7 +72,7 @@ spec:
         backend:
           service:
             name: ret
-            port: 
+            port:
               number: 4001
   - host: assets.$HUB_DOMAIN
     http:
@@ -82,28 +82,28 @@ spec:
         backend:
           service:
             name: ret
-            port: 
+            port:
               number: 4001
       - path: /http
         pathType: ImplementationSpecific  # haproxy's "Begin with"
         backend:
           service:
             name: ret
-            port: 
+            port:
               number: 4001
       - path: /hubs
         pathType: Prefix
         backend:
           service:
             name: hubs
-            port: 
+            port:
               number: 8080
       - path: /spoke
         pathType: Prefix
         backend:
           service:
             name: spoke
-            port: 
+            port:
               number: 8080
   - host: cors.$HUB_DOMAIN
     http:
@@ -113,28 +113,28 @@ spec:
         backend:
           service:
             name: ret
-            port: 
+            port:
               number: 4001
       - path: /http
         pathType: ImplementationSpecific
         backend:
           service:
             name: ret
-            port: 
+            port:
               number: 4001
       - path: /hubs
         pathType: Prefix
         backend:
           service:
             name: hubs
-            port: 
+            port:
               number: 8080
       - path: /spoke
         pathType: Prefix
         backend:
           service:
             name: spoke
-            port: 
+            port:
               number: 8080
 ---
 apiVersion: networking.k8s.io/v1
@@ -143,7 +143,7 @@ metadata:
   name: dialog
   namespace: $Namespace
   annotations:
-    kubernetes.io/ingress.class: haproxy
+    spec.ingressClassName: haproxy
     haproxy.org/server-ssl: "true"
     haproxy.org/load-balance: "url_param roomId"
 spec:
@@ -160,7 +160,7 @@ spec:
         backend:
           service:
             name: dialog
-            port: 
+            port:
               number: 4443
 ---
 apiVersion: networking.k8s.io/v1
@@ -169,7 +169,7 @@ metadata:
   name: nearspark
   namespace: $Namespace
   annotations:
-    kubernetes.io/ingress.class: haproxy
+    spec.ingressClassName: haproxy
     haproxy.org/path-rewrite: /nearspark/(.*) /\1
 spec:
   tls:
@@ -185,7 +185,7 @@ spec:
         backend:
           service:
             name: nearspark
-            port: 
+            port:
               number: 5000
 ---
 ##############################################################################################
@@ -412,7 +412,7 @@ spec:
   minReadySeconds: 15
   strategy:
     type: RollingUpdate
-    rollingUpdate: 
+    rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1
   revisionHistoryLimit: 1
@@ -428,7 +428,7 @@ spec:
           type: DirectoryOrCreate
       - name: config
         configMap:
-          name: ret-config           
+          name: ret-config
       containers:
       - name: reticulum
         volumeMounts:
@@ -438,7 +438,7 @@ spec:
         - name: config
           mountPath: /home/ret
         securityContext:
-          privileged: true       
+          privileged: true
         image: $Container_Dockerhub_Username/reticulum:$Container_Tag
         ports:
         - containerPort: 9100
@@ -581,11 +581,11 @@ spec:
         imagePullPolicy: IfNotPresent
         env:
         - name: PGRST_LOG_LEVEL
-          value: info        
+          value: info
         - name: PGRST_DB_SCHEMA
           value: ret0_admin
         - name: PGRST_DB_ANON_ROLE
-          value: postgres          
+          value: postgres
         - name: PGRST_DB_URI
           valueFrom:
             secretKeyRef:
@@ -755,7 +755,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: configs
-              key: DB_USER          
+              key: DB_USER
         - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -797,7 +797,7 @@ spec:
   minReadySeconds: 15
   strategy:
     type: RollingUpdate
-    rollingUpdate: 
+    rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1
   template:
@@ -860,14 +860,14 @@ metadata:
   annotations:
     cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
 spec:
-  replicas: 1 
+  replicas: 1
   selector:
     matchLabels:
       app: spoke
   minReadySeconds: 15
   strategy:
     type: RollingUpdate
-    rollingUpdate: 
+    rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1
   template:
@@ -930,14 +930,14 @@ metadata:
   annotations:
     cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
 spec:
-  replicas: 1 
+  replicas: 1
   selector:
     matchLabels:
       app: nearspark
   minReadySeconds: 15
   strategy:
     type: RollingUpdate
-    rollingUpdate: 
+    rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1
   template:
@@ -963,7 +963,7 @@ spec:
     port: 5000
     targetPort: 5000
   selector:
-    app: nearspark        
+    app: nearspark
 # ---
 # ########################################################################
 # ######################   speelycaptor   ###############################
@@ -1068,7 +1068,7 @@ stringData:
 ---
 ########################################################################
 ######################   dialog   ######################################
-########################################################################  
+########################################################################
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1097,7 +1097,7 @@ spec:
       - name: dialog
         image: $Container_Dockerhub_Username/dialog:$Container_Tag
         imagePullPolicy: Always
-        ports:        
+        ports:
         - hostPort: 4443
           containerPort: 4443
         env:
@@ -1136,10 +1136,10 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: coturn                                          
+      app: coturn
   minReadySeconds: 15
   strategy:
-    type: RollingUpdate    
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -1193,7 +1193,7 @@ data:
   global-config-snippet: |
     tune.bufsize 33792
   backend-config-snippet: |
-    option forwardfor 
+    option forwardfor
     option http-pretend-keepalive
   ssl-redirect: "true"
   timeout-client: 30m
@@ -1318,7 +1318,7 @@ rules:
     - events
     - serviceaccounts
     - services
-    - endpoints    
+    - endpoints
     verbs:
     - get
     - list
@@ -1368,7 +1368,7 @@ rules:
     verbs:
     - get
     - list
-    - watch      
+    - watch
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1381,4 +1381,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: haproxy-sa
-  namespace: $Namespace 
+  namespace: $Namespace

--- a/community-edition/services/certbotbot/entrypoint.sh
+++ b/community-edition/services/certbotbot/entrypoint.sh
@@ -49,7 +49,7 @@ metadata:
   name: certbotbot-http
   namespace: ${NAMESPACE}
   annotations:
-    kubernetes.io/ingress.class: haproxy
+    spec.ingressClassName: haproxy
 spec:
   rules:
   - host: ${DOMAIN}
@@ -60,14 +60,14 @@ spec:
         backend:
           service:
             name: certbotbot-http
-            port: 
+            port:
               number: 80
 EOF
 )
   echo "${CERTBOTING}"|kubectl apply -f -
 
   echo "start nginx and wait $INGRESS_WAIT sec for ingress to pick up the pod" && nginx && sleep $INGRESS_WAIT
-  
+
   echo "requesting cert"
   retries=10
   while (( retries > 0 )) && ! certbot certonly --non-interactive --agree-tos --register-unsafely-without-email --preferred-challenges http --nginx -d $DOMAIN
@@ -131,7 +131,7 @@ echo "CP_TO_NS=$CP_TO_NS"
 echo "LETSENCRYPT_ACCOUNT=$LETSENCRYPT_ACCOUNT"
 if [ -z $INGRESS_WAIT ]; then INGRESS_WAIT="30"; fi
 
-if ! [ -z $LETSENCRYPT_ACCOUNT ]; then 
+if ! [ -z $LETSENCRYPT_ACCOUNT ]; then
   acctDir="/etc/letsencrypt/accounts/acme-v02.api.letsencrypt.org/directory/"
   mkdir -p $acctDir
   echo $LETSENCRYPT_ACCOUNT | base64 -d > acct.tar.gz && tar -xf acct.tar.gz -C $acctDir
@@ -160,7 +160,7 @@ for ns in ${CP_TO_NS//,/ }; do save_cert $CERT_NAME $ns; done
 
 # if [ "$NAMESPACE" == "ingress" ]; then kubectl -n $NAMESPACE rollout restart deployment haproxy; fi
 
-if [ -z $LETSENCRYPT_ACCOUNT ]; then 
+if [ -z $LETSENCRYPT_ACCOUNT ]; then
   cd /etc/letsencrypt/accounts/acme*/directory/ && tar -czvf acct.tar.gz .
   acct=$(cat acct.tar.gz|base64)
   echo "reporting new letsencrypt account to orch: $acct"


### PR DESCRIPTION
This is based on the warning message:

Warning: annotation "kubernetes.io/ingress.class" is deprecated, please use 'spec.ingressClassName' instead

I'm not sure how best to test this, so it might be best for someone to cherry-pick this commit as part of other changes, instead of this being a separate PR.