### PR TITLE
Adds error output to ssl_script/index.js

### DIFF
--- a/community-edition/ssl_script/index.js
+++ b/community-edition/ssl_script/index.js
@@ -12,7 +12,8 @@ function generate_ssl(config, template, url) {
   config.HUB_DOMAIN = url;
   const replacedContent = utils.replacePlaceholders(template, config);
   utils.writeOutputFile(replacedContent, "ssl_script", "cbb.yaml");
-  try {execSync(`kubectl apply -f cbb.yaml`, {cwd: "ssl_script"})} catch {
+  try {execSync(`kubectl apply -f cbb.yaml`, {cwd: "ssl_script"})} catch (error) {
+    console.error(`while executing kubectl apply -f cbb.yaml:`, error);
     process.exit(1);
   }
   // check the status of the SSL certificate generation
@@ -21,26 +22,29 @@ function generate_ssl(config, template, url) {
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10000);
     // Get the status of the certbotbot-http pod
     try {
-      output = execSync(`kubectl get pod certbotbot-http -n ${config.Namespace} --no-headers -o custom-columns=STATUS:.status.phase`);
-    } catch {
-      process.exit(1);
-    }
-    if (output.toString().trim() == "Running") {
-      process.stdout.write(".");
-    }
-    else if (output.toString().trim() == "Succeeded") {
-      console.log(":");
-      try {
-        output = execSync(`kubectl get secret cert-${url} -n ${config.Namespace}`);
-        console.log(output.toString());
-      } catch {
-        process.exit(1);
+      let output = execSync(`kubectl get pod certbotbot-http -n ${config.Namespace} --no-headers -o custom-columns=STATUS:.status.phase`);
+
+      if (output.toString().trim() === "Running") {
+        process.stdout.write(".");
       }
-      return
-    }
-    else {
-      console.log(`bad pod status: ${output.toString().trim()}`)
-      return
+      else if (output.toString().trim() === "Succeeded") {
+        console.log(":");
+        try {
+          output = execSync(`kubectl get secret cert-${url} -n ${config.Namespace}`);
+          console.log(output.toString());
+          return;
+        } catch (error) {
+          console.error(`while executing kubectl get secret cert-${url} -n ${config.Namespace}:`, error);
+          process.exit(1);
+        }
+      }
+      else {
+        console.log(`bad pod status: ${output.toString().trim()}`)
+        return;
+      }
+    } catch (error) {
+      console.error(`while executing kubectl get pod certbotbot-http -n ${config.Namespace} --no-headers -o custom-columns=STATUS:.status.phase:`, error);
+      process.exit(1);
     }
   }
 }


### PR DESCRIPTION
In both the old and new code, errors thrown by execSync are caught and the process exited. The new code just brings the comparisons and logging inside the try-catch. In the unlikely event that they threw an error, that would almost certainly be a coding error, in which case the process should exit. However, that code is so simple that practically speaking, the new and old code are equivalent.  I believe this way is more idiomatic.

Supersedes https://github.com/hrithikwins/ce-npm/pull/5