### PR TITLE
Persistent volumes are created dynamically, w/ default storageClass

### DIFF
--- a/community-edition/generate_script/hcce.yam
+++ b/community-edition/generate_script/hcce.yam
@@ -673,7 +673,7 @@ spec:
                   key: DB_NAME
           volumeMounts:
             - name: postgresql-data
-              mountPath: /var/lib/postgresql/data
+              mountPath: /var/lib/postgresql
       volumes:
         - name: postgresql-data
           hostPath:
@@ -1060,14 +1060,6 @@ spec:
     targetPort: 5000
   selector:
     app: photomnemonic
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: configs
-  namespace: $Namespace
-stringData:
-  PSQL: $PSQL
 ---
 ########################################################################
 ######################   dialog   ######################################

--- a/community-edition/generate_script/persistent_volume_claims.yam
+++ b/community-edition/generate_script/persistent_volume_claims.yam
@@ -1,0 +1,26 @@
+######################################################################################
+############################## persistent volume claims ###############################
+######################################################################################
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pgsql-pvc
+  namespace: $Namespace
+spec:
+  accessModes:
+    - ReadWriteOncePod
+  resources:
+    requests:
+      storage: $PERSISTENT_VOLUME_SIZE
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ret-pvc
+  namespace: $Namespace
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: $PERSISTENT_VOLUME_SIZE

--- a/community-edition/generate_script/persistent_volumes.yam
+++ b/community-edition/generate_script/persistent_volumes.yam
@@ -1,30 +1,42 @@
 ######################################################################################
 ################################# persistent volume ##################################
 ######################################################################################
----
-######################################################################################
-############################## persistent volume claim ###############################
-######################################################################################
 apiVersion: v1
-kind: PersistentVolumeClaim
+kind: PersistentVolume
 metadata:
-  name: pgsql-pvc
-  namespace: $Namespace
+  name: pgsql-pv
+  labels:
+    type: local
 spec:
-  accessModes:
-    - ReadWriteOncePod
-  resources:
-    requests:
-      storage: $PERSISTENT_VOLUME_SIZE
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: ret-pvc
-  namespace: $Namespace
-spec:
+  storageClassName: manual
+  capacity:
+    storage:  $PERSISTENT_VOLUME_SIZE
   accessModes:
     - ReadWriteOnce
-  resources:
-    requests:
-      storage: $PERSISTENT_VOLUME_SIZE
+  persistentVolumeReclaimPolicy: Retain
+  claimRef:
+    name: pgsql-pvc
+    namespace: $Namespace
+  hostPath:
+    path: "/mnt/pgsql_data"
+    type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: ret-pv
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage:  $PERSISTENT_VOLUME_SIZE
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  claimRef:
+    name: ret-pvc
+    namespace: $Namespace
+  hostPath:
+    path: "/mnt/ret_storage_data"
+    type: DirectoryOrCreate

--- a/community-edition/generate_script/persistent_volumes.yam
+++ b/community-edition/generate_script/persistent_volumes.yam
@@ -1,45 +1,6 @@
 ######################################################################################
 ################################# persistent volume ##################################
 ######################################################################################
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: pgsql-pv
-  labels:
-    type: local
-spec:
-  storageClassName: manual
-  capacity:
-    storage:  $PERSISTENT_VOLUME_SIZE
-  accessModes:
-    - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Retain
-  claimRef:
-    name: pgsql-pvc
-    namespace: $Namespace
-  hostPath:
-    path: "/mnt/pgsql_data"
-    type: DirectoryOrCreate
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: ret-pv
-  labels:
-    type: local
-spec:
-  storageClassName: manual
-  capacity:
-    storage:  $PERSISTENT_VOLUME_SIZE
-  accessModes:
-    - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Retain
-  claimRef:
-    name: ret-pvc
-    namespace: $Namespace
-  hostPath:
-    path: "/mnt/ret_storage_data"
-    type: DirectoryOrCreate
 ---
 ######################################################################################
 ############################## persistent volume claim ###############################
@@ -50,9 +11,8 @@ metadata:
   name: pgsql-pvc
   namespace: $Namespace
 spec:
-  storageClassName: manual
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteOncePod
   resources:
     requests:
       storage: $PERSISTENT_VOLUME_SIZE
@@ -63,7 +23,6 @@ metadata:
   name: ret-pvc
   namespace: $Namespace
 spec:
-  storageClassName: manual
   accessModes:
     - ReadWriteOnce
   resources:

--- a/community-edition/input-values.yaml
+++ b/community-edition/input-values.yaml
@@ -20,6 +20,7 @@ PHX_KEY: "changeMe"
 SKETCHFAB_API_KEY: "?"
 TENOR_API_KEY: "?"
 GENERATE_PERSISTENT_VOLUMES: "Yes"
+PERSISTENT_VOLUME_STORAGE_CLASS: "default"   # or 'manual' for a single-node test installations
 PERSISTENT_VOLUME_SIZE: "10Gi"
 OVERRIDE_RETICULUM_IMAGE: "hubsfoundation/reticulum:$Container_Tag"
 OVERRIDE_POSTGREST_IMAGE: "No"

--- a/community-edition/readme.md
+++ b/community-edition/readme.md
@@ -45,6 +45,8 @@ Before applying the configuration file to your Kubernetes cluster, you will need
 To deploy to your K8s cluster on your chosen hosting solution, follow these steps:
 
 - In `input-values.yaml` edit `HUB_DOMAIN`, `ADM_EMAIL`, `SMTP_SERVER`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS` and optionally `SKETCHFAB_API_KEY` with the values for your site.  Change `NODE_COOKIE`, `GUARDIAN_KEY`, & `PHX_KEY` to unique random values, using a password generator if you have one handy.
+For a single-node test (not production) instance, you can set `PERSISTENT_VOLUME_STORAGE_CLASS` to `manual` to save a few bucks.
+For a custom setup, you can set `PERSISTENT_VOLUME_STORAGE_CLASS` to any storage class supported on your cluster.
 - Run `npm run gen-hcce && npm run apply` to generate your configuration in `hcce.yaml` and apply it to your K8s cluster. From the output read your load balancer's external IP address.
 - Expose the services
   - On your DNS service, create four A-records to route your domains to the external IP address of your load balancer


### PR DESCRIPTION
hostPath volumes are labeled a "dangerous escape hatch" in the documentation, and will be discarded if there is ever a second node.  There are several mechanisms where this may happen, even for a "single-node" cluster, such as when the version of Kubernetes is upgraded by spinning up a new node, then draining and spinning down the old.

This PR creates volumes 
1. off the node, so they outlast nodes
2. using the cluster's default storage class. This is either the provider's default (which is some standard/general purpose flavor of storage for every provider I checked), or was specifically set by the cluster's administrator.

Cloud Provider | Default StorageClass Name | Default Provisioner
-- | -- | --
Amazon Web Services | gp2 | aws-ebs
Microsoft Azure | standard | azure-disk
Google Cloud Platform | standard | gce-pd
OpenStack | standard | cinder
VMware vSphere | thin | vsphere-volume
DigitalOcean | do-block-storage | dobs.csi.digitalocean.com
Scaleway | sbs-default | csi.scaleway.com

3. that can be backed-up and restored on a different provider
4. can be expanded (usually)

Currently, DigitalOcean charges $1/mo for a 10GB volume, so this PR adds $2/mo to a default installation.

See [my blob post](https://hominidsoftware.com/tech-personal-growth/Hubs-on-DigitalOcean/) for background.

It also creates the pgsql volume with accessMode ReadWriteOncePod. If someone ever tries to scale up the pgsql deployment, this will ensure only one PostgresQL engine can access the files, so they aren't corrupted. (ReadWriteOnce allows all pods on the node to access the volume.)

It also tweaks the mountPath for PostgresQL so it's **not** creating files and directories at the root of the volume, so PostresQL doesn't balk at the presence of a `lost+found` directory.

It also removes the duplicate Secret.


This PR has been tested on Digital Ocean; it would be desirable to validate it on another provider.