### PR TITLE
Change Community Edition license to MPL-2.0

### DIFF
--- a/community-edition/package.json
+++ b/community-edition/package.json
@@ -12,7 +12,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MPL-2.0",
   "description": "",
   "dependencies": {
     "inquirer": "^10.0.1",


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Changes the license for the Community Edition Node scripts to be MPL-2.0, the same as the top level license on this repository.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
The license should always have been MPL-2.0, but it was missed that the license wasn't MPL-2.0 when the initial pull request that added the Node scripts was reviewed.

## Examples
<!-- If applicable, give examples of your changes, screenshots, videos, etc. -->
N/A

## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->
N/A

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
N/A

## Limitations
<!-- List anything that isn't addressed, e.g. corner cases, and why they weren't addressed -->
None known.

## Alternatives considered
<!-- If there are any alternative ways of implementing this that you thought of, but decided against, list them here along with why they were discarded -->
None.

## Open questions
<!-- List any questions you have -->
In order to re-license this, everyone who contributed code to the Community Edition Node scripts needs to sign off on it.  As far as I can tell, the following people besides me have contributed to the Community Edition Node scripts:

@hrithikwins
@DougReeder
@rashedafridi

Do you all consent to re-licensing the Community Edition Node scripts to MPL-2.0?

## Additional details or related context
<!-- Give any other details that you think the reviewers should be aware of -->
The PR that introduced the ISC license: https://github.com/Hubs-Foundation/hubs-cloud/pull/352

This should probably be merged into the `master` branch and then the `development` branch rebased on `master`.