### PR TITLE
Fix PostgreSQL data persistence

### DIFF
--- a/community-edition/generate_script/hcce.yam
+++ b/community-edition/generate_script/hcce.yam
@@ -671,9 +671,11 @@ spec:
                 secretKeyRef:
                   name: configs
                   key: DB_NAME
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
           volumeMounts:
             - name: postgresql-data
-              mountPath: /var/lib/postgresql
+              mountPath: /var/lib/postgresql/data
       volumes:
         - name: postgresql-data
           hostPath:


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Returns the mountPath for the postgresql-data volume back to it's original value and adds the PGDATA environment variable to the container to specify that the PostgreSQL data be stored in a further subfolder.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
Changing the mountPath doesn't actually change where the data is written, instead it causes Docker to create an anonymous volume at the default path that is discarded when the container/pod is deleted (which loses all the data).

Using the PGDATA environment variable to specify that the PostgreSQL data be stored in a further subfolder should continue to avoid the issue of a lost+found folder being created somewhere PostgreSQL doesn't like it.

## Examples
<!-- If applicable, give examples of your changes, screenshots, videos, etc. -->
N/A

## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

1. Delete your instance, e.g. `kubectl delete -f hcce.yaml`.
2. Redeploy your instance with the changes from this PR.
3. Add some data to your instance.
4. Delete your deployment/pods and redeploy your instance.
5. See that your data is still there (previously these steps would have resulted in your data being lost).

Note: if you want to preserve your old data you should back it up first with the backup scripts from PR #382 

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
This fixes a bug in the current behavior, so no documentation change is needed.

## Limitations
<!-- List anything that isn't addressed, e.g. corner cases, and why they weren't addressed -->
This will need to be updated in the future because future versions of PostgreSQL expect the data to be stored in version specific folders.

## Alternatives considered
<!-- If there are any alternative ways of implementing this that you thought of, but decided against, list them here along with why they were discarded -->
None.

## Open questions
<!-- List any questions you have -->
None.

## Additional details or related context
<!-- Give any other details that you think the reviewers should be aware of -->
PR https://github.com/Hubs-Foundation/hubs-cloud/pull/363

References:
https://www.linode.com/community/questions/22421/why-is-postgres-data-deleted-when-pod-restarted-on-kubernetes
https://datageek.blog/2020/06/17/disappearing-data-in-postgresql/
https://stackoverflow.com/questions/58069267/postgres-running-on-kubernetes-looses-data-upon-pod-recreation-or-cluster-reboot
https://github.com/docker-library/postgres/issues/263#issuecomment-460998040
https://hub.docker.com/_/postgres#pgdata
https://github.com/docker-library/docs/blob/master/postgres/README.md
https://github.com/docker-library/postgres/blob/e2a43025b1acedac60ddfad3678ed5da1a09fd79/12/alpine3.21/Dockerfile
https://github.com/docker-library/postgres/blob/master/18/alpine3.22/Dockerfile